### PR TITLE
feat: add getValues method to Form class

### DIFF
--- a/.changeset/better-parks-live.md
+++ b/.changeset/better-parks-live.md
@@ -1,0 +1,5 @@
+---
+"mobx-react-hook-form": minor
+---
+
+Added getValues method to Form class

--- a/src/mobx-form/mobx-form.ts
+++ b/src/mobx-form/mobx-form.ts
@@ -22,6 +22,7 @@ import {
   type SetValueConfig,
   set,
   type UseFormClearErrors,
+  type UseFormGetValues,
   type UseFormRegister,
   type UseFormReset,
   type UseFormResetField,
@@ -268,6 +269,29 @@ export class Form<
   setValue: UseFormSetValue<TFieldValues>;
 
   /**
+   * Get a single field value, or a group of fields value.
+   *
+   * @remarks
+   * [API](https://react-hook-form.com/docs/useform/getvalues) • [Demo](https://codesandbox.io/s/react-hook-form-v7-ts-getvalues-txsfg)
+   *
+   * @param fieldNames - the path name to the form field value.
+   * @param options - returns only dirty fields or return only touchedFields
+   *
+   * @example
+   * ```tsx
+   * // Update a single field
+   * getValues('name', 'value', {
+   *   dirtyFields: true, // returns only dirty fields
+   *   touchedFields: true, // returns only touchedFields
+   * });
+   *
+   * // Get nested values
+   * getValues('root.nested.0.value');
+   * ```
+   */
+  getValues: UseFormGetValues<TFieldValues>;
+
+  /**
    * Reset at the entire form state.
    *
    * @remarks
@@ -354,6 +378,7 @@ export class Form<
       set(this.values, args[0], args[1]);
       return this.originalForm.setValue(...args);
     });
+    this.getValues = this.originalForm.getValues;
     this.resetForm = action((...args) => {
       let defaultValues = args[0] ?? this.defaultValues;
 


### PR DESCRIPTION
Добавлен `getValues` для удобного доступа к вложенным полям через нотацию пути. Прямой доступ к `mobxForm.values` не поддерживает парсинг путей вроде `name.0.nested.0`, что необходимо при работе со сложными структурами данных.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `getValues()` method added to the Form class, allowing you to retrieve individual field values or groups of field values from your forms.

* **Chores**
  * Updated mobx-react-hook-form dependency to a new minor version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->